### PR TITLE
Added filter for spaces incase the script includes non-role lines

### DIFF
--- a/scripts/role-deps.sh
+++ b/scripts/role-deps.sh
@@ -73,8 +73,8 @@ set_roles_path() {
 # Find dependencies in the specified playbook
 find_dependencies() {
   grep '    - .*\..*' "${playbook}" \
-    | grep --invert-match " " \
     | cut --characters=7- \
+	| grep --invert-match " " \
     | sort --unique
 }
 

--- a/scripts/role-deps.sh
+++ b/scripts/role-deps.sh
@@ -73,6 +73,7 @@ set_roles_path() {
 # Find dependencies in the specified playbook
 find_dependencies() {
   grep '    - .*\..*' "${playbook}" \
+    | grep --invert-match " " \
     | cut --characters=7- \
     | sort --unique
 }


### PR DESCRIPTION
When merged this PR will:
- Added a filter to the role-dep.sh to exclude any lines picked up from the role search that contain spaces.

Roles must default to 'namerole.maintainer' so anything including a space will not be valid.